### PR TITLE
ability to add entities to fisca request body

### DIFF
--- a/routes/results/convertToFlags.spec.js
+++ b/routes/results/convertToFlags.spec.js
@@ -2,6 +2,7 @@ const { convertToFlags } = require('./convertToFlags')
 
 describe('Test the convertToFlag data converter', () => {
   let datetimeSpy
+  const dateString = '2020-08'
   beforeEach(() => {
     datetimeSpy = jest.spyOn(Date, 'now')
     datetimeSpy.mockImplementation(() => {
@@ -10,82 +11,308 @@ describe('Test the convertToFlag data converter', () => {
   })
 
   test('It converts data to flags according to the definition', () => {
-    const converterMap = {
-      some_question_key: {
-        'some-defined-answer': {
-          some: true,
-          nice: true,
-          flags: true,
-        },
-      },
-      some_other_question: {
-        'some-answer-not-answered': {
-          not_included: true,
-        },
-      },
-    }
-
-    const data = {
-      some_question_key: 'some-defined-answer',
-      some_other_question: 'not-included',
-      another_question: 'hello',
-    }
-
-    const result = convertToFlags(data, converterMap)
-    expect(result).toEqual({
-      some: {
-        '2020-08-10': true,
-      },
-      nice: {
-        '2020-08-10': true,
+    const conversionMap = {
+      entities: {
+        person: [
+          "some_benefit",
+        ],
       },
       flags: {
-        '2020-08-10': true,
+        some_flag: {
+          person: {
+            "some-value": {
+              my_flag: true,
+            },
+          },
+        },
       },
-      another_question: {
-        '2020-08-10': 'hello',
+    }
+
+    const dataMap = {
+      some_flag: "some-value",
+    }
+
+    const result = convertToFlags(dataMap, conversionMap)
+
+    expect(result).toEqual(
+      {
+        persons: {
+          person: {
+            my_flag: {
+              [dateString]: true,
+            },
+            some_benefit: {
+              [dateString]: null,
+            },
+          },
+        },
       },
-      cerb_eligible: {
-        '2020-08-10': null,
-      },
-      cesb_eligible: {
-        '2020-08-10': null,
-      },
-      ei_workshare_eligible: {
-        '2020-08-10': null,
-      },
-      mortgage_deferral_eligible: {
-        '2020-08-10': null,
-      },
-      rent_help_eligible: {
-        '2020-08-10': null,
-      },
-      student_loan_eligible: {
-        '2020-08-10': null,
-      },
-      ccb_payment_eligible: {
-        '2020-08-10': null,
-      },
-      oas_eligible: {
-        '2020-08-10': null,
-      },
-      dtc_oas_eligible: {
-        '2020-08-10': null,
-      },
-      dtc_individual_eligible: {
-        '2020-08-10': null,
-      },
-      dtc_child_eligible: {
-        '2020-08-10': null,
-      },
-      rrif_eligible: {
-        '2020-08-10': null,
-      },
-      student_financial_aid_eligible: {
-        '2020-08-10': null,
-      },
-    })
+    )
   })
+
+  test('It omits fields that are not defined in the conversion map', () => {
+    const conversionMap = {
+      entities: {
+        person: [
+          "some_benefit",
+        ],
+      },
+      flags: {
+        some_flag: {
+          person: {
+            "some-value": {
+              my_flag: true,
+              my_other_flag: true,
+            },
+          },
+        },
+      },
+    }
+
+    const dataMap = {
+      some_flag: "some-value",
+      some_other_field: "some-other-value",
+    }
+
+    const result = convertToFlags(dataMap, conversionMap)
+
+    expect(result).toEqual(
+      {
+        persons: {
+          person: {
+            my_flag: {
+              [dateString]: true,
+            },
+            my_other_flag: {
+              [dateString]: true,
+            },
+            some_benefit: {
+              [dateString]: null,
+            },
+          },
+        },
+      },
+    )
+
+  })
+
+  test("It omits an entity when there are no fields besides benefits", () =>{
+    const conversionMap = {
+      entities: {
+        person: [
+          "some_benefit",
+        ],
+      },
+      flags: {
+        some_flag: {
+          person: {
+            "some-value": {
+              my_flag: true,
+            },
+          },
+        },
+      },
+    }
+
+    const dataMap = {
+      some_other_field: "some-other-value",
+    }
+
+    const result = convertToFlags(dataMap, conversionMap)
+
+    expect(result).toEqual(
+      {
+        persons: {},
+      },
+    )
+
+  })
+
+  test("It omits fields with values that are not defined in the conversion map", () => {
+    const conversionMap = {
+      entities: {
+        person: [
+          "some_benefit",
+        ],
+      },
+      flags: {
+        some_flag: {
+          person: {
+            "some-value": {
+              my_flag: true,
+            },
+          },
+        },
+      },
+    }
+
+    const dataMap = {
+      some_flag: "some-other-value",
+    }
+
+    const result = convertToFlags(dataMap, conversionMap)
+
+    expect(result).toEqual(
+      {
+        persons: {},
+      },
+    )
+
+
+  })
+
+  test("It supports multiple entities", () => {
+    const conversionMap = {
+      entities: {
+        person: [
+          "some_benefit",
+        ],
+        child: [
+          "some_other_benefit",
+        ],
+      },
+      flags: {
+        some_flag: {
+          person: {
+            "some-value": {
+              my_flag: true,
+            },
+          },
+          child: {
+            "some-value": {
+              my_child_flag: true,
+            },
+          },
+        },
+        some_other_field: {
+          child: {
+            "some-other-value": {
+              my_other_child_flag: true,
+            },
+          },
+        },
+      },
+    }
+
+    const dataMap = {
+      some_flag: "some-value",
+      some_other_field: "some-other-value",
+    }
+
+    const result = convertToFlags(dataMap, conversionMap)
+
+    expect(result).toEqual(
+      {
+        persons: {
+          person: {
+            my_flag: {
+              [dateString]: true,
+            },
+            some_benefit: {
+              [dateString]: null,
+            },
+          },
+          child: {
+            my_child_flag: {
+              [dateString]: true,
+            },
+            my_other_child_flag: {
+              [dateString]: true,
+            },
+            some_other_benefit: {
+              [dateString]: null,
+            },
+          },
+        },
+      },
+    )
+  })
+
+  test("Adds family object when defined", () => {
+    const conversionMap = {
+      entities: {
+        person: [
+          "some_benefit",
+        ],
+        child: [
+          "some_other_benefit",
+        ],
+      },
+      flags: {
+        some_flag: {
+          person: {
+            "some-value": {
+              my_flag: true,
+            },
+          },
+          child: {
+            "some-value": {
+              my_child_flag: true,
+            },
+          },
+        },
+        some_other_field: {
+          child: {
+            "some-other-value": {
+              my_other_child_flag: true,
+            },
+          },
+        },
+      },
+      families: {
+        "f1": {
+          entities: ["person", "child"],
+          data: {
+            "parents": ["person"],
+            "children": ["child"],
+          },
+        },
+      },
+    }
+
+    const dataMap = {
+      some_flag: "some-value",
+      some_other_field: "some-other-value",
+    }
+
+
+    const result = convertToFlags(dataMap, conversionMap)
+
+    expect(result).toEqual(
+      {
+        persons: {
+          person: {
+            my_flag: {
+              [dateString]: true,
+            },
+            some_benefit: {
+              [dateString]: null,
+            },
+          },
+          child: {
+            my_child_flag: {
+              [dateString]: true,
+            },
+            my_other_child_flag: {
+              [dateString]: true,
+            },
+            some_other_benefit: {
+              [dateString]: null,
+            },
+          },
+        },
+        families: {
+          "f1": {
+            "parents": ["person"],
+            "children": ["child"],
+          },
+        },
+      },
+    )
+
+  })
+
+
 
   afterEach(() => {
     datetimeSpy.mockRestore()

--- a/routes/results/getBenefits.js
+++ b/routes/results/getBenefits.js
@@ -3,19 +3,21 @@ const path = require('path')
 
 // go through keys and push benefits which have a true key-value pair
 const getBenefits = (data) => {
-  const results = []
+  const results = {}
   const dataKeys = Object.keys(data)
-  for (const i in Object.keys(data)) {
-    const key = dataKeys[i]
-    if (key.endsWith('_eligible')) {
-      const benefit = key.split('__is_eligible')
-      const valuesforBenefit = Object.values(data[key])
-      if (valuesforBenefit.length > 0 && valuesforBenefit[0] === true) {
-        results.push(benefit[0])
+  for(const entity in data){
+    for (const i in Object.keys(data[entity])) {
+      const key = dataKeys[i]
+      if (key.endsWith('_eligible')) {
+        const benefit = key.split('__is_eligible')
+        const valuesforBenefit = Object.values(data[entity][key])
+        if (valuesforBenefit.length > 0 && valuesforBenefit[0] === true) {
+          results[benefit[0]] = 1
+        }
       }
     }
   }
-  return results
+  return Object.keys(results)
 }
 
 const getProvincialBenefits = (data) => {

--- a/routes/results/results.controller.js
+++ b/routes/results/results.controller.js
@@ -35,7 +35,7 @@ const getData = (req, res) => {
       return {}
     }
   }
-  
+
   const render = (req, res, name, viewData, resData) => {
     // get All Benefits (except provinces and GST)
     if (resData) {
@@ -44,7 +44,7 @@ const getData = (req, res) => {
       'gst_credit',
     )
 
-    const benefits = getBenefits(resData.persons.person)
+    const benefits = getBenefits(resData.persons)
 
     let unavailableBenefits = benefitsFullList.filter(
       (benefit) => !benefits.includes(benefit),
@@ -87,12 +87,7 @@ module.exports = (app, route) => {
     .get((req, res) => {
       res.locals.simpleRoute = (name, locale) => simpleRoute(name, locale)
       const data = getData(req, res)
-      const dataFlags = convertToFlags(data, conversionMap)
-      const requestBody = {
-        persons: {
-          person: dataFlags,
-        },
-      }
+      const requestBody = convertToFlags(data, conversionMap)
 
       if(process.env.NODE_ENV === 'test') {
         render(req, res, name, data, testData)
@@ -109,7 +104,6 @@ module.exports = (app, route) => {
             if (fiscaRes.ok) {
               return fiscaRes.json()
             } else {
-              console.log(fiscaRes)
               res.status(500)
               res.render('500', {
                 message: 'OpenFisca returned a bad response',

--- a/utils/openfisca.config.js
+++ b/utils/openfisca.config.js
@@ -1,110 +1,166 @@
-// first level is the key, second is the value of the key and third are the boolean flags to set
 const conversionMap = {
-  lost_job: {
-    'lost-all-income': {
-      income_status__has_lost_all_income: true,
-    },
-    'lost-some-income': {
-      income_status__has_lost_some_income: true,
-    },
-    'lost-no-income': {
-      income_status__has_lost_no_income: true,
+  entities:{
+    // entities with the fields to calculate (i.e. those that are set to null)
+    person: [
+      "cerb__is_eligible",
+      "cesb__is_eligible",
+      "ei_workshare__is_eligible",
+      "mortgage_deferral__is_eligible",
+      "rent__is_eligible",
+      "student_loan__is_eligible",
+      "oas__is_eligible",
+      "dtc__is_eligible_for_dtc_and_oas",
+      "dtc__is_eligible",
+      "student_financial_help__is_eligible",
+      "riff__is_eligible",
+    ],
+    child: [
+      "dtc__is_eligible",
+    ],
+  },
+  families: {
+    // how entities are combined
+    "f1": {
+      entities: ["person", "child"],
+      data: {
+        "parents": ["person"],
+        "children": ["child"],
+      },
     },
   },
-  no_income: {
+  flags: {
+    // flags conversion for entities
     lost_job: {
-      income_status_reason__has_lost_job: true,
+      person: {
+        'lost-all-income': {
+          income_status__has_lost_all_income: true,
+        },
+        'lost-some-income': {
+          income_status__has_lost_some_income: true,
+        },
+        'lost-no-income': {
+          income_status__has_lost_no_income: true,
+        },
+      },
     },
-    employer_closed: {
-      income_status_reason__has_employer_closed: true,
+    no_income: {
+      person: {
+        lost_job: {
+          income_status_reason__has_lost_job: true,
+        },
+        employer_closed: {
+          income_status_reason__has_employer_closed: true,
+        },
+        'self-employed-closed': {
+          income_status_reason__has_self_employee_with_no_income: true,
+        },
+        'unpaid-leave-to-care': {
+          income_status_reason__has_unpaid_leave_to_care_for_child_or_sick: true,
+        },
+      },
     },
-    'self-employed-closed': {
-      income_status_reason__has_self_employee_with_no_income: true,
+    some_income: {
+      person: {
+        'hours-reduced': {
+          income_status_reason__has_hours_reduced: true,
+        },
+        'selfemployed-some-income': {
+          income_status_reason__is_self_employed_some_income: true,
+        },
+        'employed-lost-a-job': {
+          income_status_reason__employed_lost_a_job: true,
+        },
+        quarantine: {
+          income_status_reason__is_quarantined: true,
+          income_status_reason__has_unpaid_leave_to_care_for_child_or_sick: true,
+        },
+      },
     },
-    'unpaid-leave-to-care': {
-      income_status_reason__has_unpaid_leave_to_care_for_child_or_sick: true,
+    unchanged_income: {
+      person:{
+        wfh: {
+          working_from_home: true, // not flag for working from home
+        },
+        'paid-leave': {
+          // no flag for paid-leave
+          on_paid_leave: true,
+        },
+        student_2019_2020: {
+          is_student_2019_2020: true,
+        },
+        high_school_grad: {
+          is_high_school_grad: true,
+        },
+      },
     },
-  },
-  some_income: {
-    'hours-reduced': {
-      income_status_reason__has_hours_reduced: true,
+    mortgage_payments: {
+      person: {
+        'yes-mortgage': {
+          mortgage_deferral__has_mortgage_payments: true,
+        },
+        'yes-rent': {
+          rent__has_need_for_rent_help: true,
+        },
+      },
     },
-    'selfemployed-some-income': {
-      income_status_reason__is_self_employed_some_income: true,
+    gross_income: {
+      person: {
+        'over_5k': {
+          income_status_reason__is_gross_income_over_5k: true,
+        },
+        '4999_or_less': {
+          income_status_reason__is_gross_income_over_5k: false,
+        },
+      },
     },
-    'employed-lost-a-job': {
-      income_status_reason__employed_lost_a_job: true,
+    student_debt: {
+      person:{
+        yes: {
+          student_loan__has_student_debt: true,
+        },
+      },
     },
-    quarantine: {
-      income_status_reason__is_quarantined: true,
-      income_status_reason__has_unpaid_leave_to_care_for_child_or_sick: true,
+    plans_for_school: {
+      person: {
+        yes: {
+          student_financial_help__has_plan_for_school: true,
+        },
+      },
     },
-  },
-  unchanged_income: {
-    wfh: {
-      working_from_home: true, // not flag for working from home
-    },
-    'paid-leave': { 
-      // no flag for paid-leave
-      on_paid_leave: true,
-    },
-    student_2019_2020: {
-      is_student_2019_2020: true,
-    },
-    high_school_grad: {
-      is_high_school_grad: true,
-    },
-  },
-  mortgage_payments: {
-    'yes-mortgage': {
-      mortgage_deferral__has_mortgage_payments: true,
-    },
-    'yes-rent': {
-      rent__has_need_for_rent_help: true,
-    },
-  },
-  gross_income: {
-    'over_5k': {
-      income_status_reason__is_gross_income_over_5k: true,
-    },
-    '4999_or_less': {
-      income_status_reason__is_gross_income_over_5k: false,
-    },
-  },
-  student_debt: {
-    yes: {
-      student_loan__has_student_debt: true,
-    },
-  },
-  plans_for_school: {
-    yes: {
-      student_financial_help__has_plan_for_school: true,
-    },
-  },
-  oas: {
     oas: {
-      has_oas: true,
+      person: {
+        oas: {
+          has_oas: true,
+        },
+        allowance: {
+          has_allowance: true,
+        },
+        survivor: {
+          has_allowance_for_survivor: true,
+        },
+      },
     },
-    allowance: {
-      has_allowance: true,
+    rrif: {
+      person: {
+        yes: {
+          riff__has_riff: true,
+        },
+      },
     },
-    survivor: {
-      has_allowance_for_survivor: true,
+    ccb: {
+      person: {
+        yes: {
+          canada_child_benefit__yes_or_unsure: true,
+        },
+      },
+    },
+    ei_workshare: {
+      person: {
+        income_status__has_lost_some_income: true,
+      },
     },
   },
-  rrif: {
-    yes: {
-      riff__has_riff: true,
-    },
-  },
-  ccb: {
-    yes: {
-      canada_child_benefit__yes_or_unsure: true,
-    },
-  },
-  ei_workshare: {
-    income_status__has_lost_some_income: true,
-  },
+
 }
 module.exports = {
   conversionMap,


### PR DESCRIPTION
# Description

Added the ability to specify the entity in the conversion map so that flags are able to be split across multiple entities 


## Test Instructions

1. Open convertToFlags.js and convertToFlags.spec.js
2. Run the unit tests to confirm it works 


## Checklist
- [ ] Update CHANGELOG.md
- [x ] Unit tests have been added/updated
- [ ] e2e tests have been added/updated