### PR TITLE
Corrected flag labels to match questionnaire answer values

### DIFF
--- a/utils/openfisca.config.js
+++ b/utils/openfisca.config.js
@@ -45,10 +45,10 @@ const conversionMap = {
     },
     no_income: {
       person: {
-        lost_job: {
+        'lost-job': {
           income_status_reason__has_lost_job: true,
         },
-        employer_closed: {
+        'employer-closed': {
           income_status_reason__has_employer_closed: true,
         },
         'self-employed-closed': {


### PR DESCRIPTION
# Description

OpenFisca API was not getting the response values for the income_status__reason variable required to check for CERB eligibility. This was due to unmatched labels between the questionnaire and what the flag converter is looking for.

## Test Instructions

1. Run openfisca-canada and the benefits finder
1. Answer lost all income with reasons either lost job or employee closed
1. Continue to end of questionnaire and see that eligibility for CERB is true